### PR TITLE
Model required expenditure

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,6 +71,13 @@ def main():
     )
 
     parser.add_argument(
+        '--required-expenditure',
+        type=int,
+        default=0,
+        help='Required expenditure to apply at the end of the simulation'
+    )
+
+    parser.add_argument(
         '--epochs',
         type=int,
         default=1,
@@ -92,7 +99,7 @@ def main():
     # Create simulator
     if args.add_resources == 0:
         args.add_resources = m.total_resources
-    simulator = Simulator(m, args.method, args.add_resources, args.target_node, args.income_tax_rate, args.seed)
+    simulator = Simulator(m, args.method, args.add_resources, args.target_node, args.income_tax_rate, args.required_expenditure, args.seed)
 
     print(f"Created model with {args.nodes} nodes, each starting with {args.resources} resources")
     print(f"Initial total resources: {m.total_resources}")

--- a/rgrr/tests/test_simulator.py
+++ b/rgrr/tests/test_simulator.py
@@ -79,6 +79,29 @@ class TestSimulator(unittest.TestCase):
         self.assertEqual(simulator.total_tax_collected, 8)
         self.assertEqual(self.m.total_resources, sum(initial_resources) + 100)
 
+    def test_apply_required_expenditure(self):
+        expenditure_per_node = 5
+        resources_to_add = 0 # No resources added for this test
+        simulator = Simulator(self.m, 'random', resources_to_add, required_expenditure=expenditure_per_node, seed=42)
+        initial_total_resources = self.m.total_resources
+        initial_node_resources = [node.resources for node in self.m.Nodes]
+
+        simulator.run()
+
+        # Calculate expected total expenditure
+        expected_total_expenditure = 0
+        for res in initial_node_resources:
+            expected_total_expenditure += min(res, expenditure_per_node)
+
+        self.assertGreater(expected_total_expenditure, 0)
+        self.assertEqual(simulator.total_expenditure_incurred, expected_total_expenditure)
+        self.assertEqual(self.m.total_resources, initial_total_resources - expected_total_expenditure)
+
+        for i, node in enumerate(self.m.Nodes):
+            expected_resources = initial_node_resources[i] - min(initial_node_resources[i], expenditure_per_node)
+            self.assertEqual(node.resources, expected_resources)
+
+
 class TestMultiStepSimulator(unittest.TestCase):
     def setUp(self):
         self.initial_nodes = 5


### PR DESCRIPTION
Required expenditure is a fixed resource count that's subtracted from each node's resource count at the end of an epoch.

There are multiple problems with this approach:

- Resources disappear. They should be included in the next epoch.
- If resources for a node become zero that node will never get any resources. There should also be a corresponding min-income setting.