### PR TITLE
Histogram navigation with next and prev buttons

### DIFF
--- a/client/src/main/rgrr/client/app.cljs
+++ b/client/src/main/rgrr/client/app.cljs
@@ -8,7 +8,8 @@
             [reagent.dom.client :as rdc]))
 
 (def histogram-data (atom {}))
-(def histogram-index (atom 0))
+(def histogram-index (r/atom 0))
+(def histogram-current (r/atom ()))
 
 (defn fetch-histogram []
   (go
@@ -27,29 +28,34 @@
    []))
 
 (defn render-histogram []
-  (rdc/render @root
-              [:div
-               [:div {:style {:width "100%" :height "500px"}}
-                [:> ResponsiveBar
-                 {:data (get-histogram-data @histogram-index)
-                  :keys ["density"]
-                  :height 500
-                  :width 400
-                  :margin {:top 50 :right 50 :bottom 50 :left 60}
-                  :padding 0.05
-                  :animate false
-                  :enableLabel false}]]
-               (let [max-index (- (count (:epoch_distributions @histogram-data)) 1)]
-                 [:div
-                  [:button {:disabled (or (empty? @histogram-data) (= @histogram-index 0))
-                            :onClick #(if (> @histogram-index 0) (swap! histogram-index dec))}
-                   "Previous"]
-                  [:button {:disabled (or (empty? @histogram-data) (= @histogram-index max-index))
-                            :onClick #(if (< @histogram-index max-index) (swap! histogram-index inc))}
-                   "Next"]])]))
+  (let [data (get-histogram-data @histogram-index)
+        epoch-max (- (count (:epoch_distributions @histogram-data)) 1)]
+    (rdc/render @root
+                [(fn []
+                   [:div
+                    [:div {:style {:width "100%" :height "500px"}}
+                     [:> ResponsiveBar
+                      {:data @histogram-current
+                       :keys ["density"]
+                       :height 500
+                       :width 400
+                       :margin {:top 50 :right 50 :bottom 50 :left 60}
+                       :padding 0.05
+                       :enableLabel false}]]
+                    [:div
+                     [:button {:disabled (or (empty? @histogram-data) (= @histogram-index 0))
+                               :onClick #(if (> @histogram-index 0) (swap! histogram-index dec))}
+                      "Previous"]
+                     [:button {:disabled (or (empty? @histogram-data) (= @histogram-index epoch-max))
+                               :onClick #(if (< @histogram-index epoch-max) (swap! histogram-index inc))}
+                      "Next"]]])])))
+
+(defn update-current []
+  (reset! histogram-current (get-histogram-data @histogram-index)))
 
 (add-watch histogram-data :redisplay render-histogram)
-(add-watch histogram-index :redisplay render-histogram)
+(add-watch histogram-data :set-epoch update-current)
+(add-watch histogram-index :set-epoch update-current)
 
 (defn ^:export ^:dev/after-load init []
   (fetch-histogram))


### PR DESCRIPTION
Add next and prev buttons to navigate through histograms. Clean up histogram presentation. Use reagent correctly, where we're updating histogram data which introduces animation and makes clear how the Y scale's changing.