### PR TITLE
Add endpoint to list all simulation IDs

### DIFF
--- a/server/rgrr/plotting.py
+++ b/server/rgrr/plotting.py
@@ -3,8 +3,6 @@ from matplotlib.widgets import RadioButtons
 import numpy as np
 from scipy.stats import pareto
 
-from .simulation_store import get_simulation
-
 class EpochPlotter:
     def __init__(self):
         self.fig, self.ax = plt.subplots()
@@ -14,6 +12,7 @@ class EpochPlotter:
         self.ylim = None
 
     def plot_current_epoch(self):
+        from .simulation_store import get_simulation # Imported locally to prevent circular dependency
         self.ax.clear()
         distributions = get_simulation("dummy").distributions
         distribution = distributions[self.current_epoch - 1]
@@ -40,6 +39,7 @@ class EpochPlotter:
         plt.draw()
 
     def key_press(self, event):
+        from .simulation_store import get_simulation # Imported locally to prevent circular dependency
         distributions = get_simulation("dummy").distributions
         if event.key == 'right':
             if self.current_epoch < len(distributions):
@@ -55,6 +55,7 @@ class EpochPlotter:
                     self.radio.set_active(self.current_epoch - 1)
 
     def show(self):
+        from .simulation_store import get_simulation # Imported locally to prevent circular dependency
         distributions = get_simulation("dummy").distributions
         # Determine global x and y ranges
         global_min_x, global_max_x = float('inf'), float('-inf')

--- a/server/rgrr/server.py
+++ b/server/rgrr/server.py
@@ -236,9 +236,32 @@ def run_simulation(id):
         return jsonify({"error": f"Failed to run simulation {id}: {str(e)}"}), 500
 
 
+@app.route('/simulations', methods=['GET'])
+def list_simulations():
+    """
+    ---
+    get:
+      summary: Get a list of all simulation IDs
+      responses:
+        200:
+          description: A list of simulation IDs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+    """
+    simulation_ids = sr.list_simulation_ids()
+    return jsonify(simulation_ids)
+
+
 with app.test_request_context():
     spec.path(view=get_distribution)
+    spec.path(view=get_histogram)
+    spec.path(view=create_simulation)
     spec.path(view=run_simulation)
+    spec.path(view=list_simulations)
 
 
 @app.route('/swagger.json')

--- a/server/rgrr/simulation_store.py
+++ b/server/rgrr/simulation_store.py
@@ -1,11 +1,19 @@
 from typing import List
+from rgrr.simulator import MultiStepSimulator
 
 simulations = {}
 
-def store_simulation(id: str, simulator: "MultiStepSimulator"):
+def store_simulation(id: str, simulator: MultiStepSimulator):
     global simulations
     simulations[id] = simulator
 
-def get_simulation(id: str) -> "MultiStepSimulator":
+def get_simulation(id: str) -> MultiStepSimulator:
     global simulations
     return simulations.get(id)
+
+
+def list_simulation_ids() -> List[str]:
+    """
+    Returns a list of all simulation IDs currently stored.
+    """
+    return list(simulations.keys())

--- a/server/rgrr/tests/test_server.py
+++ b/server/rgrr/tests/test_server.py
@@ -112,3 +112,43 @@ class TestServerEndpoints(unittest.TestCase):
         self.assertIsInstance(hist_data['bin_edges'], list)
         self.assertIsInstance(hist_data['epoch_distributions'], list)
         self.assertGreater(len(hist_data['epoch_distributions']), 0)
+
+    def test_list_simulations_empty(self):
+        """
+        Test that GET /simulations returns an empty list when no simulations exist.
+        """
+        response = self.test_app.get('/simulations')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), [])
+
+    def test_list_simulations_with_data(self):
+        """
+        Test that GET /simulations returns a list of simulation IDs when simulations exist.
+        """
+        # Create a first simulation
+        response1 = self.test_app.post('/simulations', json={
+            "nodes": 10,
+            "epochs": 1,
+            "resources_per_node": 10,
+            "operations": [{"type": "random", "resources_added": 100}]
+        })
+        self.assertEqual(response1.status_code, 201)
+        sim_id1 = response1.get_json()['id']
+
+        # Create a second simulation
+        response2 = self.test_app.post('/simulations', json={
+            "nodes": 5,
+            "epochs": 2,
+            "resources_per_node": 5,
+            "operations": [{"type": "uniform", "resources_added": 50}]
+        })
+        self.assertEqual(response2.status_code, 201)
+        sim_id2 = response2.get_json()['id']
+
+        list_response = self.test_app.get('/simulations')
+        self.assertEqual(list_response.status_code, 200)
+        retrieved_ids = list_response.get_json()
+        self.assertIsInstance(retrieved_ids, list)
+        self.assertIn(sim_id1, retrieved_ids)
+        self.assertIn(sim_id2, retrieved_ids)
+        self.assertEqual(len(retrieved_ids), 2)


### PR DESCRIPTION
* Import MultiStepSimulator for type hints in simulation_store.
* Resolve circular import by removing get_simulation from plotting, and importing only locally when needed.
* Additional fixes to API declaration in server.
* Implement and update tests.